### PR TITLE
WAIFU-8: Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM alpine:latest AS build
+
+# Install software
+RUN apk update && apk upgrade && apk add --no-cache curl musl-dev gcc
+
+# Add to non-root user
+RUN adduser -D -u 1000 rasopus
+
+# Copy source code from host
+WORKDIR /app
+COPY . .
+# We can't use the cache anyways because we compile against musl. Deleting this makes chown/chmod run way faster.
+RUN rm -rf /app/target
+RUN chown -R rasopus:rasopus /app
+RUN chmod -R 755 /app
+
+# Switch to non-root user
+USER rasopus
+
+# Install Rust toolchain for user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/home/rasopus/.cargo/bin:${PATH}"
+
+# Build the project
+RUN cargo build --release
+
+################################################################################
+FROM alpine:latest AS runtime
+
+# Install software
+RUN apk update && apk upgrade
+
+# Uninstall non-necessary software
+RUN rm -rf /var/cache/apk/* && rm -rf /tmp/* && rm /sbin/apk
+
+# Create a non-root user
+RUN adduser -D -u 1000 rasopus
+USER rasopus
+
+# Copy necessary files from the build container
+WORKDIR /app
+COPY --from=build /app/target/release/rasopus .
+
+# Default command
+CMD ["./rasopus"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  rasopus:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    environment:
+      - ROCKET_ADDRESS=0.0.0.0
+      - ROCKET_SECRET_KEY=pnUM94/8LhhtSE1REEihKj7npG6+lvigAy4C885fIzY=

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 services:
-  rasopus:
+  rasopus-backend:
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
This PR introduces a multi-stage Dockerfile for building an Alpine Linux container running the Rasopus backend. A docker-compose.yml is provided for easier starting/stopping for the container.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R45): Added a multi-stage build process. The build stage installs necessary tools and dependencies, sets up a non-root user, and compiles the project. The runtime stage only includes the compiled binary and minimal dependencies, running as a non-root user. Additional hardening is done by deleting Alpine's package manager, apk.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R1-R10): Introduced a `docker-compose.yml` file to define the `rasopus-backend` service, specifying the build context and Dockerfile, mapping the necessary ports, and setting environment variables for the application.