### PR TITLE
fix: release comparison

### DIFF
--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -27,12 +27,12 @@ jobs:
         run: cargo search
       - name: Read crates.io version
         id: crates_io_version
-        run: echo "version=$(cargo search | grep -m 1 '^rasopus-backend ' | awk '{print $2}'" >> $GITHUB_OUTPUT
+        run: echo "version=$(cargo search --limit 1 $(cargo read-manifest | jq -r .name) | awk '{print $3}' |  tr -d '"') >> $GITHUB_OUTPUT
       - name: Parse and compare versions
         run: |
           source_version="${{ steps.source_version.outputs.version }}"
           crates_io_version="${{ steps.crates_io_version.outputs.version }}"
-          if [ "$(printf '%s\n' "$crates_io_version" "$source_version" | sort -V | head -n1)" != "$source_version" ]; then
+          if [ "$(printf '%s\n%s\n' "$source_version" "$crates_io_version" | sort -V | tail -n1)" = "$source_version" ] && [ "$source_version" != "$crates_io_version" ]; then
             echo "Source branch version ($source_version) is higher than crates.io version ($crates_io_version)."
           else
             echo "Source branch version ($source_version) is not higher than crates.io version ($crates_io_version)."


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/deploy_release.yml` file to improve the process of reading and comparing version numbers from `crates.io`. The main changes involve modifying the command to fetch the version from `crates.io` and updating the version comparison logic.

Improvements to version handling in deployment workflow:

* Updated the command to read the version from `crates.io` to use `cargo read-manifest` and `jq` for more accurate extraction of the package name and version.
* Modified the version comparison logic to ensure the source branch version is correctly identified as higher than the `crates.io` version, using `tail -n1` instead of `head -n1` in the comparison.